### PR TITLE
Integer overflow and a potential bug fixed

### DIFF
--- a/SwiftzMac/APMutableParams.m
+++ b/SwiftzMac/APMutableParams.m
@@ -32,9 +32,9 @@
     unsigned char buffer[length];
     [data getBytes:buffer length:length];
 
-    unsigned char offset = 0;
+    unsigned int offset = 0;
     
-    while (offset < sizeof(buffer)) {
+    while (offset < sizeof(buffer) -2) {
         unsigned char key = buffer[offset];
         unsigned char length = buffer[offset + 1];
 


### PR DESCRIPTION
It crashed cuz a long and not regular supplicant protocol packet made by server side (message field etc.. ) overflow the theoretical type (char) of offset .
one more things, a potential bug may be encountered when the key of last field is the end of the buffer but taking other unrelated stack as the length of that field under the incomplete server side packet .
